### PR TITLE
Update if_wg.h

### DIFF
--- a/src/uapi/openbsd/net/if_wg.h
+++ b/src/uapi/openbsd/net/if_wg.h
@@ -89,7 +89,6 @@ struct wg_interface_io {
     uint8_t			i_public[WG_KEY_LEN];
     uint8_t			i_private[WG_KEY_LEN];
     size_t			i_peers_count;
-    struct wg_peer_io	i_peers[];
 
     uint16_t 			i_junk_packet_count;
     uint16_t 			i_junk_packet_min_size;
@@ -100,6 +99,7 @@ struct wg_interface_io {
     uint32_t 			i_response_packet_magic_header;
     uint32_t 			i_underload_packet_magic_header;
     uint32_t 			i_transport_packet_magic_header;
+    struct wg_peer_io	i_peers[];
 };
 
 struct wg_data_io {


### PR DESCRIPTION
fixed this build error:

```
uapi/openbsd/net/if_wg.h:93:23: error: flexible array member 'i_peers' with type 'struct wg_peer_io[]' is not at the end of struct
    struct wg_peer_io   i_peers[];
                        ^
uapi/openbsd/net/if_wg.h:94:17: note: next field declaration is here
    uint16_t                    i_junk_packet_count;

```