### PR TITLE
fix #40: key length comparison in config.c

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -33,7 +33,7 @@ static const char *get_value(const char *line, const char *key)
 	size_t linelen = strlen(line);
 	size_t keylen = strlen(key);
 
-	if (keylen >= linelen)
+	if (keylen > linelen)
 		return NULL;
 
 	if (strncasecmp(line, key, keylen))


### PR DESCRIPTION
We already have checking emptiness of string in parsers, so empty value is valid. Fixes #40 