### PR TITLE
[CHERRY-PICK] wg-quick: linux: do not unnecessarily set sysctl

### DIFF
--- a/src/wg-quick/linux.bash
+++ b/src/wg-quick/linux.bash
@@ -237,7 +237,7 @@ add_default() {
 	printf -v restore '%sCOMMIT\n*mangle\n-I POSTROUTING -m mark --mark %d -p udp -j CONNMARK --save-mark %s\n-I PREROUTING -p udp -j CONNMARK --restore-mark %s\nCOMMIT\n' "$restore" $table "$marker" "$marker"
 	printf -v nftcmd '%sadd rule %s %s postmangle meta l4proto udp mark %d ct mark set mark \n' "$nftcmd" "$pf" "$nftable" $table
 	printf -v nftcmd '%sadd rule %s %s premangle meta l4proto udp meta mark set ct mark \n' "$nftcmd" "$pf" "$nftable"
-	[[ $proto == -4 ]] && cmd sysctl -q net.ipv4.conf.all.src_valid_mark=1
+	[[ $proto == -4 ]] && [[ $(sysctl -n net.ipv4.conf.all.src_valid_mark) -ne 1 ]] && cmd sysctl -q net.ipv4.conf.all.src_valid_mark=1
 	if type -p nft >/dev/null; then
 		cmd nft -f <(echo -n "$nftcmd")
 	else


### PR DESCRIPTION
Found a bug in some scenario while using docker. There is a fix in original WG-Quick repo for it already. TBH, I don't know the sync process of the repo, probably the maintainers are going to update the repo in the nearest future... Anyway, PTAL

--- Original commit comment ---
In some restrictive container namespaces, sysctl is locked down and can't be changed. This shouldn't be a problem, though, at least in theory, because net.ipv4.conf.all.src_valid_mark is already 1. However, currently wg-quick unconditionally sets it. Instead, check to see if it's already 1 before trying make it 1.

Suggested-by: Dean P <dean@apakossa.org>