### PR TITLE
ci: publish arm64 Linux release artifacts

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -52,9 +52,58 @@ jobs:
         name: alpine-3.19-amneziawg-tools
         path: ./src/build
 
+  Build-for-Ubuntu-arm64:
+    name: Build for Ubuntu (arm64)
+    runs-on: ubuntu-24.04-arm
+    container:
+      image: ubuntu:22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build AmneziaWG tools
+      run: |
+        apt -y update &&
+        apt -y install build-essential &&
+        cd src &&
+        make &&
+        mkdir build &&
+        cp wg ./build/awg &&
+        cp wg-quick/linux.bash ./build/awg-quick
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ubuntu-22.04-arm64-amneziawg-tools
+        path: ./src/build
+
+  Build-for-Alpine-arm64:
+    name: Build for Alpine (arm64)
+    runs-on: ubuntu-24.04-arm
+    container:
+      image: alpine:3.19
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build AmneziaWG tools
+      run: |
+        apk add linux-headers build-base &&
+        cd src &&
+        make &&
+        mkdir build &&
+        cp wg ./build/awg &&
+        cp wg-quick/linux.bash ./build/awg-quick
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: alpine-3.19-arm64-amneziawg-tools
+        path: ./src/build
+
   GitHub-Release:
     name: GitHub Release
-    needs: [Build-for-Ubuntu, Build-for-Alpine]
+    needs: [Build-for-Ubuntu, Build-for-Alpine, Build-for-Ubuntu-arm64, Build-for-Alpine-arm64]
     strategy:
       matrix:
         include:
@@ -62,6 +111,10 @@ jobs:
             release: "22.04"
           - os: "alpine"
             release: "3.19"
+          - os: "ubuntu"
+            release: "22.04-arm64"
+          - os: "alpine"
+            release: "3.19-arm64"
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:


### PR DESCRIPTION
## What

Publish arm64 Linux release artifacts: `ubuntu-22.04-arm64-amneziawg-tools.zip` and `alpine-3.19-arm64-amneziawg-tools.zip`.

## Why

Current releases ship Linux binaries for amd64 only, so arm64 users (Raspberry Pi, AWS Graviton, Oracle Ampere, Hetzner CAX) have to compile from source. This also blocks arm64 support in the `amneziavpn/amneziawg-go` Docker image, whose Dockerfile downloads `alpine-3.19-amneziawg-tools.zip` — see amnezia-vpn/amneziawg-go#65 and amnezia-vpn/amnezia-client#869.

## How

Purely additive: two new build jobs mirroring the existing Ubuntu 22.04 and Alpine 3.19 jobs, running on GitHub's native `ubuntu-24.04-arm` runners (free for public repositories, no QEMU needed), plus two new matrix entries in the release job. Existing jobs, artifact names, and release assets are unchanged.

## Testing

Ran the exact CI build commands in `--platform linux/arm64` containers (Alpine 3.19 and Ubuntu 22.04): both build cleanly, `./wg --version` → `amneziawg-tools v1.0.20210914`, `uname -m` → `aarch64`. Binaries were also verified working on a Raspberry Pi 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
