### PR TITLE
config: allow empty I2-I5 values

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -33,7 +33,7 @@ static const char *get_value(const char *line, const char *key)
 	size_t linelen = strlen(line);
 	size_t keylen = strlen(key);
 
-	if (keylen >= linelen)
+	if (keylen > linelen)
 		return NULL;
 
 	if (strncasecmp(line, key, keylen))


### PR DESCRIPTION
This fixes parsing of empty config values such as `I2=`.

Currently `get_value()` returns NULL when the input line length is equal
to the key length. For a line like `I2=`, this causes the parser to reject
the line with:

    Line unrecognized: 'I2='

Empty `I2-I5` values can appear in AmneziaWG configs, so the parser should
only reject lines shorter than the requested key.

Related to #35, but fixes a narrower case: empty I2-I5 values.